### PR TITLE
Refactor to exclude folders from installing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-recursive-install [![Build Status](https://travis-ci.org/emgeee/recursive-install.svg?branch=master)](https://travis-ci.org/emgeee/recursive-install)
+recursive-install-with-token
 ===
 
 A small utility to recursively run `npm install` in any child directory that has a `package.json` file excluding sub directories of `node_modules`.
 
 Preinstall
 ---
-You will need an `NPM_TOKEN` environment variable, and it should contain your npm `Auth Token`
+You will need an `NPM_TOKEN` environment variable, and it should contain your npm `Auth Token`.
+Optionally include `EXCLUDE_FOLDERS` environment variable to exclude folders
+Ex: `packages, cypress` Note: case-sensitive
 
 Install
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recursive-npm-install-with-token",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recursive-npm-install-with-token",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recursive-npm-install-with-token",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recursive-npm-install-with-token",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "CLI tool to recursive search child directories and run 'npm install' when a package.json file is found.",
   "main": "recursive-install.js",
   "keywords": [
@@ -16,12 +16,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/emgeee/recursive-install"
+    "url": "https://github.com/rivial-data-security/recursive-install"
   },
-  "author": "Matt Green <mgreen9@gmail.com> (https://greenin.space)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/emgeee/recursive-install/issues"
+    "url": "https://github.com/rivial-data-security/recursive-install/issues"
   },
   "dependencies": {
     "shelljs": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recursive-npm-install-with-token",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "CLI tool to recursive search child directories and run 'npm install' when a package.json file is found.",
   "main": "recursive-install.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recursive-npm-install-with-token",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "CLI tool to recursive search child directories and run 'npm install' when a package.json file is found.",
   "main": "recursive-install.js",
   "keywords": [

--- a/recursive-install.js
+++ b/recursive-install.js
@@ -40,7 +40,7 @@ function npmInstall(dir) {
                     if (typeof str === 'string') return str.trim();
                 });
 
-            if(foldersToExclude && Array.isArray(foldersToExclude) && foldersToExclude.length > 0) {
+            if(Array.isArray(foldersToExclude) && foldersToExclude.length > 0) {
                 /**
                  * Check if current folder needs to be excluded
                  */

--- a/recursive-install.js
+++ b/recursive-install.js
@@ -5,58 +5,97 @@ var shell = require('shelljs')
 var execSync = require('child_process').execSync
 var argv = require('yargs').argv
 
-function noop (x) { return x }
-
-function getPackageJsonLocations (dirname) {
-  return shell.find(dirname)
-    .filter(function (fname) {
-      return !(fname.indexOf('node_modules') > -1 || fname[0] === '.') &&
-        path.basename(fname) === 'package.json'
-    })
-    .map(function (fname) {
-      return path.dirname(fname)
-    })
+function noop(x) {
+    return x
 }
 
-function npmInstall (dir) {
-  var exitCode = 0;
-  try {
-    if(argv.production) {
-      console.log('Installing ' + dir + '/package.json with --production option')
-      execSync('echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc', { cwd: dir})
-      execSync('npm install --production', { cwd: dir})
-    } else {
-      console.log('Installing ' + dir + '/package.json')
-      execSync('echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc', { cwd: dir})
-      execSync('npm install', { cwd: dir})
+function getPackageJsonLocations(dirname) {
+    return shell.find(dirname)
+        .filter(function (fname) {
+            return !(fname.indexOf('node_modules') > -1 || fname[0] === '.') &&
+                path.basename(fname) === 'package.json'
+        })
+        .map(function (fname) {
+            return path.dirname(fname)
+        })
+}
+
+function npmInstall(dir) {
+    var exitCode = 0;
+    try {
+
+        let foldersToExclude = [];
+
+        /**
+         * Environment variable called "EXCLUDE_FOLDERS" with an array of strings. Note: case-sensitive
+         * Ex: packages, containers, etc..
+         */
+        const excludeFolders = process.env.EXCLUDE_FOLDERS;
+
+        if (excludeFolders && typeof excludeFolders === 'string') {
+            foldersToExclude = excludeFolders
+                .split(",")
+                .map((str) => {
+                    /**
+                     * Remove white space from the beginning or end of a string
+                     */
+                    if (typeof str === 'string') return str.trim();
+                });
+
+            if(foldersToExclude && Array.isArray(foldersToExclude) && foldersToExclude.length > 0) {
+                /**
+                 * Check if current folder needs to be excluded
+                 */
+                const foundFolderToExclude = foldersToExclude.find((x) => x === dir);
+
+                /**
+                 * If folder to exclude found, return without installing packages
+                 */
+                if(foundFolderToExclude) {
+                    return {
+                        dirname: dir,
+                        exitCode: exitCode
+                    }
+                }
+            }
+        }
+
+        if (argv.production) {
+            console.log('Installing ' + dir + '/package.json with --production option')
+            execSync('echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc', {cwd: dir})
+            execSync('npm install --production', {cwd: dir})
+        } else {
+            console.log('Installing ' + dir + '/package.json')
+            execSync('echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc', {cwd: dir})
+            execSync('npm install', {cwd: dir})
+        }
+        console.log('')
+    } catch (err) {
+        exitCode = err.status
     }
-    console.log('')
-  } catch (err) {
-    exitCode = err.status
-  }
 
-  return {
-    dirname: dir,
-    exitCode: exitCode
-  }
+    return {
+        dirname: dir,
+        exitCode: exitCode
+    }
 }
 
-function filterRoot (dir) {
-  if (path.normalize(dir) === path.normalize(process.cwd())) {
-    console.log('Skipping root package.json')
-    return false
-  } else {
-    return true
-  }
+function filterRoot(dir) {
+    if (path.normalize(dir) === path.normalize(process.cwd())) {
+        console.log('Skipping root package.json')
+        return false
+    } else {
+        return true
+    }
 }
 
 if (require.main === module) {
-  var exitCode = getPackageJsonLocations(argv.rootDir ? argv.rootDir : process.cwd())
-    .filter(argv.skipRoot ? filterRoot : noop)
-    .map(npmInstall)
-    .reduce(function (code, result) {
-      return result.exitCode > code ? result.exitCode : code
-    }, 0)
+    var exitCode = getPackageJsonLocations(argv.rootDir ? argv.rootDir : process.cwd())
+        .filter(argv.skipRoot ? filterRoot : noop)
+        .map(npmInstall)
+        .reduce(function (code, result) {
+            return result.exitCode > code ? result.exitCode : code
+        }, 0)
 
-  process.exit(exitCode)
+    process.exit(exitCode)
 }

--- a/recursive-install.js
+++ b/recursive-install.js
@@ -24,8 +24,6 @@ function npmInstall(dir) {
     var exitCode = 0;
     try {
 
-        let foldersToExclude = [];
-
         /**
          * Environment variable called "EXCLUDE_FOLDERS" with an array of strings. Note: case-sensitive
          * Ex: packages, containers, etc..
@@ -33,7 +31,7 @@ function npmInstall(dir) {
         const excludeFolders = process.env.EXCLUDE_FOLDERS;
 
         if (excludeFolders && typeof excludeFolders === 'string') {
-            foldersToExclude = excludeFolders
+            const foldersToExclude = excludeFolders
                 .split(",")
                 .map((str) => {
                     /**
@@ -46,7 +44,13 @@ function npmInstall(dir) {
                 /**
                  * Check if current folder needs to be excluded
                  */
-                const foundFolderToExclude = foldersToExclude.find((x) => x === dir);
+                let foundFolderToExclude = false;
+
+                const currentPathFolders = dir.split("/");
+
+                for(const folder of foldersToExclude) {
+                    foundFolderToExclude = currentPathFolders.find((x) => x === folder);
+                }
 
                 /**
                  * If folder to exclude found, return without installing packages


### PR DESCRIPTION
Exclude specific folders from installing packages

Environment variable called "EXCLUDE_FOLDERS" with an array of strings. Note: case-sensitive
       Ex: packages, containers

Downside: if multiple folders have the same name all of them will be ignored